### PR TITLE
Allow loose matching of route regardless of trailing slash

### DIFF
--- a/src/Smrtr/HaltoRouter.php
+++ b/src/Smrtr/HaltoRouter.php
@@ -166,7 +166,7 @@ class HaltoRouter
      *
      * @return array|boolean Array with route information on success, false on failure (no match).
      */
-    public function match($requestUrl, $requestMethod, $requestHost, $looseMatching)
+    public function match($requestUrl, $requestMethod, $requestHost, $looseMatching = false)
     {
         $params = array();
         $validGroups = $this->getValidHostGroups($requestHost);
@@ -193,15 +193,15 @@ class HaltoRouter
             }
 
             if ($looseMatching) {
-                if (substr($_route, strlen($_route) - 1, 1) === '$') {
+                if (substr($_route, -1) === '$') {
                    if (substr($_route, strlen($_route) - 2, 1) === '/') {
                        $_route = sprintf('%s?$', substr($_route, 0, strlen($_route) - 1));
-                   } elseif (substr($_route, strlen($_route) - 2, 2) !== '/?') {
+                   } elseif (substr($_route, -2) !== '/?') {
                        $_route = sprintf('%s/?$', substr($_route, 0, strlen($_route) - 1));
                    }
-                } elseif (substr($_route, strlen($_route) - 1, 1) === '/') {
+                } elseif (substr($_route, -1) === '/') {
                     $_route = sprintf('%s?', $_route);
-                } elseif (substr($_route, strlen($_route) - 2, 2) !== '/?') {
+                } elseif (substr($_route, -2) !== '/?') {
                     $_route = sprintf('%s/?', $_route);
                 }
             } 

--- a/src/Smrtr/HaltoRouter.php
+++ b/src/Smrtr/HaltoRouter.php
@@ -162,10 +162,11 @@ class HaltoRouter
      * @param string $requestUrl
      * @param string $requestMethod
      * @param string $requestHost
+     * @param bool   $looseMatching
      *
      * @return array|boolean Array with route information on success, false on failure (no match).
      */
-    public function match($requestUrl, $requestMethod, $requestHost)
+    public function match($requestUrl, $requestMethod, $requestHost, $looseMatching)
     {
         $params = array();
         $validGroups = $this->getValidHostGroups($requestHost);
@@ -190,6 +191,20 @@ class HaltoRouter
             if (!$method_match) {
                 continue;
             }
+
+            if ($looseMatching) {
+                if (substr($_route, strlen($_route) - 1, 1) === '$') {
+                   if (substr($_route, strlen($_route) - 2, 1) === '/') {
+                       $_route = sprintf('%s?$', substr($_route, 0, strlen($_route) - 1));
+                   } elseif (substr($_route, strlen($_route) - 2, 2) !== '/?') {
+                       $_route = sprintf('%s/?$', substr($_route, 0, strlen($_route) - 1));
+                   }
+                } elseif (substr($_route, strlen($_route) - 1, 1) === '/') {
+                    $_route = sprintf('%s?', $_route);
+                } elseif (substr($_route, strlen($_route) - 2, 2) !== '/?') {
+                    $_route = sprintf('%s/?', $_route);
+                }
+            } 
 
             if ($_route === '*') {
                 $match = true;

--- a/tests/HaltoRouterTest.php
+++ b/tests/HaltoRouterTest.php
@@ -302,6 +302,23 @@ class HaltoRouterTest extends \PHPUnit_Framework_TestCase
 		$this->assertFalse($this->router->match('/foo/test/do', 'POST', 'www.example.com'));
 	}
 
+       /**
+        * @covers Smrtr\HaltoRouter::match
+        * @covers Smrtr\HaltoRouter::compileRoute
+        */
+       public function testLooseMatching()
+       {
+           $this->router->map('GET', '/foo/[:controller]/[:action]', 'foo_action', 'foo_route');
+
+           $this->assertSame(array(
+               'target' => 'Test@do',
+               'params' => array(),
+               'name' => 'foo_route'
+           ), $this->router->match('/foo/test/do/', 'GET', 'www.example.com', true));
+
+           $this->assertFalse($this->router->match('/foo/test/do/', 'POST', 'www.example.com'));
+       } 
+
     /**
      * @covers Smrtr\HaltoRouter::match
      * @covers Smrtr\HaltoRouter::compileRoute

--- a/tests/HaltoRouterTest.php
+++ b/tests/HaltoRouterTest.php
@@ -302,23 +302,39 @@ class HaltoRouterTest extends \PHPUnit_Framework_TestCase
 		$this->assertFalse($this->router->match('/foo/test/do', 'POST', 'www.example.com'));
 	}
 
-       /**
-        * @covers Smrtr\HaltoRouter::match
-        * @covers Smrtr\HaltoRouter::compileRoute
-        */
-       public function testLooseMatching()
-       {
-           $this->router->map('GET', '/foo/[:controller]/[:action]', 'foo_action', 'foo_route');
+   /**
+    * @covers Smrtr\HaltoRouter::match
+    * @covers Smrtr\HaltoRouter::compileRoute
+    */
+   public function testLooseMatchingRouteNotDefineSlash()
+   {
+       $this->router->map('GET', '/foo/[:controller]/[:action]', 'foo_action', 'foo_route');
 
-           $this->assertSame(array(
-               'target' => 'Test@do',
-               'params' => array(),
-               'name' => 'foo_route'
-           ), $this->router->match('/foo/test/do/', 'GET', 'www.example.com', true));
+       $this->assertSame(array(
+           'target' => 'Test@do',
+           'params' => array(),
+           'name' => 'foo_route'
+       ), $this->router->match('/foo/test/do/', 'GET', 'www.example.com', true));
 
-           $this->assertFalse($this->router->match('/foo/test/do/', 'POST', 'www.example.com'));
-       } 
+       $this->assertFalse($this->router->match('/foo/test/do/', 'POST', 'www.example.com'));
+   } 
 
+   /**
+    * @covers Smrtr\HaltoRouter::match
+    * @covers Smrtr\HaltoRouter::compileRoute
+    */
+   public function testLooseMatchingRouteDefinesSlash()
+   {
+       $this->router->map('GET', '/foo/[:controller]/[:action]/', 'foo_action', 'foo_route');
+
+       $this->assertSame(array(
+           'target' => 'Test@do',
+           'params' => array(),
+           'name' => 'foo_route'
+       ), $this->router->match('/foo/test/do', 'GET', 'www.example.com', true));
+
+       $this->assertFalse($this->router->match('/foo/test/do', 'POST', 'www.example.com'));
+   } 
     /**
      * @covers Smrtr\HaltoRouter::match
      * @covers Smrtr\HaltoRouter::compileRoute


### PR DESCRIPTION
Added an extra parameter to the match() method to allow routes to be matched regardless of whether or not they have been defined with a trailing slash.
